### PR TITLE
Search Restrictions for Owners

### DIFF
--- a/src/components/search/SearchResults.js
+++ b/src/components/search/SearchResults.js
@@ -1,5 +1,6 @@
 import React from "react"
 import { useLocation } from "react-router-dom";
+import useSimpleAuth from "../../hooks/ui/useSimpleAuth";
 import { AnimalListComponent } from "../animals/AnimalList";
 import EmployeeList from "../employees/EmployeeList";
 import { LocationList } from "../locations/LocationList";
@@ -8,6 +9,7 @@ import "./SearchResults.css"
 
 export default () => {
     const location = useLocation()
+    const { getCurrentUser } = useSimpleAuth()
 
     const displayAnimals = () => {
         //if the state passed from NavBar.js contains animals, render the animalList component using that state.
@@ -16,7 +18,7 @@ export default () => {
                 <React.Fragment>
                     <h2>Matching Animals</h2>
                     <section className="animals">
-                        <AnimalListComponent matchingAnimals={location.state?.animals}/>
+                        <AnimalListComponent matchingAnimals={location.state?.animals} />
                     </section>
                 </React.Fragment>
             )
@@ -30,7 +32,7 @@ export default () => {
                 <React.Fragment>
                     <h2>Matching Employees</h2>
                     <section className="employees">
-                        <EmployeeList matchingEmployees={location.state?.employees}/>
+                        <EmployeeList matchingEmployees={location.state?.employees} />
                     </section>
                 </React.Fragment>
             )
@@ -44,7 +46,7 @@ export default () => {
                 <React.Fragment>
                     <h2>Matching Locations</h2>
                     <section className="locations">
-                        <LocationList matchingLocations={location.state?.locations}/>
+                        <LocationList matchingLocations={location.state?.locations} />
                     </section>
                 </React.Fragment>
             )
@@ -53,12 +55,24 @@ export default () => {
 
     //return all search results as one fragment to be rendered whenever user hits enter key in search box (when user is pushed to /search) 
     return (
-        <React.Fragment>
-            <article className="searchResults">
-                {displayAnimals()}
-                {displayEmployees()}
-                {displayLocations()}
-            </article>
-        </React.Fragment>
+        <>
+            {
+                getCurrentUser().employee
+                    ? <React.Fragment>
+                        <article className="searchResults">
+                            {displayAnimals()}
+                            {displayEmployees()}
+                            {displayLocations()}
+                        </article>
+                    </React.Fragment>
+                    : <React.Fragment>
+                        <article className="searchResults">
+                            {displayEmployees()}
+                            {displayLocations()}
+                        </article>
+                    </React.Fragment>
+            }
+        </>
     )
+
 }


### PR DESCRIPTION
# Description

In SearchResults.js, added a conditional for rendering search results based on if user is an employee. Employee should see all 3 lists, whereas owners should only be able to see locations and employees.

Fixes #5 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A- Use the browser and log in as both owner and employee- test different search terms to make sure employees can see all three lists and owners can only see 2 (location and employees).
- [ ] Test B

# Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings
